### PR TITLE
Fix module error

### DIFF
--- a/dynamodb_beaker/__init__.py
+++ b/dynamodb_beaker/__init__.py
@@ -47,6 +47,7 @@ class DynamoDBNamespaceManager(OpenResourceNamespaceManager):
             return
         try:
             import boto.dynamodb2 as ddb
+            import boto.dynamodb2.table  # necessary for calling ddb.table
             from boto.dynamodb2.exceptions import ItemNotFound
         except ImportError as e:
             raise InvalidCacheBackendError('DynamoDB cache backend requires boto.')

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ install_requires = [
 
 setup(
     name='dynamodb_beaker',
-    version='0.2.0',
+    version='0.3.0',
     description='DynamoDB backend for Beaker',
     author='xica development team',
     author_email='info@xica.net',


### PR DESCRIPTION
It is necessary to import boto.dynamodb2.table before calling ddb.table and ddb.item.

```
>>> import boto.dynamodb2 as ddb
>>> ddb.table
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'module' object has no attribute 'table'
>>> import boto.dynamodb2.table
>>> ddb.table
<module 'boto.dynamodb2.table' from '/home/xica/.venvs/xica2.7/lib/python2.7/site-packages/boto/dynamodb2/table.pyc'>
```